### PR TITLE
Fix Mastodon post to include image attachment

### DIFF
--- a/.github/scripts/post-to-mastodon.js
+++ b/.github/scripts/post-to-mastodon.js
@@ -19,7 +19,7 @@ mastodon.post('media', { file: mediaData })
 
         mastodon.post('statuses', {
             status: 'New puzzle!',
-            media_ids: [attachment],
+            media_ids: [attachment.id],
         })
             .catch(error => console.error('Error posting status:', error));
     })


### PR DESCRIPTION
Fixes #28

Fix the issue with missing image attachment in Mastodon posts.

* Extract the `id` field from the attachment and use it in the `media_ids` parameter in `.github/scripts/post-to-mastodon.js`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bmordue/puzzle/issues/28?shareId=62b4381e-9a39-4a83-97b5-c948fb825d0d).