### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/bmordue/puzzle/security/code-scanning/5](https://github.com/bmordue/puzzle/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the workflow. This block will be added at the root level to apply to all jobs, ensuring that the `GITHUB_TOKEN` has only the minimal permissions required. Based on the workflow's operations, the `contents: read` permission is sufficient for most steps, as they involve checking out the repository and running tests. If any job requires additional permissions, they can be specified within that job's `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
